### PR TITLE
Add changing line commentary

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,10 @@ Response structure:
   "number": 15,
   "details": { /* hexagram data */ },
   "hasChanging": true,
+  "changingLineDetails": [
+    { "line": 2, "text": "...", "comments": "..." },
+    { "line": 5, "text": "...", "comments": "..." }
+  ],
   "transformedNumber": 32,
   "transformedDetails": { /* hexagram data */ }
 }

--- a/pages/api/reading.js
+++ b/pages/api/reading.js
@@ -38,14 +38,23 @@ export default function handler(req, res) {
   const number = hexagramIdFromLines(hex) + 1;
   const details = ichingData[number];
   const hasChanging = hex.includes(CHANGING_YANG) || hex.includes(CHANGING_YIN);
-
   let transformedNumber = null;
   let transformedDetails = null;
+  let changingLineDetails = [];
   if (hasChanging) {
-    const transformed = hex.map(l => l === CHANGING_YANG ? YIN : l === CHANGING_YIN ? YANG : l);
+    hex.forEach((l, idx) => {
+      if (l === CHANGING_YANG || l === CHANGING_YIN) {
+        const lineNo = idx + 1;
+        const lineData = details.wilhelm_lines[String(lineNo)];
+        if (lineData) {
+          changingLineDetails.push({ line: lineNo, ...lineData });
+        }
+      }
+    });
+    const transformed = hex.map(l => (l === CHANGING_YANG ? YIN : l === CHANGING_YIN ? YANG : l));
     transformedNumber = hexagramIdFromLines(transformed) + 1;
     transformedDetails = ichingData[transformedNumber];
   }
 
-  res.status(200).json({ question, number, details, hasChanging, transformedNumber, transformedDetails });
+  res.status(200).json({ question, number, details, hasChanging, transformedNumber, transformedDetails, changingLineDetails });
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -42,17 +42,29 @@ export default function Home() {
     const number = getHexagramNumber(hex);
     const details = ichingData[number];
 
+    const changingLines = [];
     const hasChanging = hex.includes(CHANGING_YANG) || hex.includes(CHANGING_YIN);
     let transformed = null;
     let transformedNumber = null;
     let transformedDetails = null;
+    let changingLineDetails = [];
     if (hasChanging) {
-      transformed = hex.map(l => l === CHANGING_YANG ? YIN : l === CHANGING_YIN ? YANG : l);
+      hex.forEach((l, idx) => {
+        if (l === CHANGING_YANG || l === CHANGING_YIN) {
+          const lineNo = idx + 1;
+          changingLines.push(lineNo);
+          const lineData = details.wilhelm_lines[String(lineNo)];
+          if (lineData) {
+            changingLineDetails.push({ line: lineNo, ...lineData });
+          }
+        }
+      });
+      transformed = hex.map(l => (l === CHANGING_YANG ? YIN : l === CHANGING_YIN ? YANG : l));
       transformedNumber = getHexagramNumber(transformed);
       transformedDetails = ichingData[transformedNumber];
     }
 
-    setResult({ question, number, details, hasChanging, transformedNumber, transformedDetails });
+    setResult({ question, number, details, hasChanging, transformedNumber, transformedDetails, changingLineDetails });
   };
 
   return (
@@ -110,6 +122,19 @@ export default function Home() {
                   </div>
                 </li>
               )}
+            {result.changingLineDetails && result.changingLineDetails.length > 0 && (
+              <li className="table-header">
+                <div className="comment-section">
+                  <h3>Changing Lines</h3>
+                  {result.changingLineDetails.map(l => (
+                    <p key={l.line}>
+                      <strong>Line {l.line}:</strong> {l.text}<br />
+                      <em>{l.comments}</em>
+                    </p>
+                  ))}
+                </div>
+              </li>
+            )}
             {result.hasChanging && (
               <li className="table-header">
                 <div className="comment-section">


### PR DESCRIPTION
## Summary
- detect changing lines when generating hexagrams
- render changing line commentary in the UI
- expose changing line details from the `/api/reading` endpoint
- document the new API field `changingLineDetails`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fd2deeb44832e8a4be83d666ff9e3