### PR TITLE
Fix missing helper and extraneous lines

### DIFF
--- a/pages/api/reading.js
+++ b/pages/api/reading.js
@@ -63,5 +63,3 @@ function collectChangingLineDetails(hex, details) {
   });
   return changingLineDetails;
 }
-  res.status(200).json({ question, number, details, hasChanging, transformedNumber, transformedDetails, changingLineDetails });
-}

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,6 +32,25 @@ function getHexagramNumber(hex) {
   return hexagramIdFromLines(hex) + 1;
 }
 
+function processChangingLines(hex, details) {
+  const changingLines = [];
+  const changingLineDetails = [];
+  hex.forEach((l, idx) => {
+    if (l === CHANGING_YANG || l === CHANGING_YIN) {
+      const lineNo = idx + 1;
+      changingLines.push(lineNo);
+      const lineData = details.wilhelm_lines[String(lineNo)];
+      if (lineData) {
+        changingLineDetails.push({ line: lineNo, ...lineData });
+      }
+    }
+  });
+  const transformed = hex.map(l => (l === CHANGING_YANG ? YIN : l === CHANGING_YIN ? YANG : l));
+  const transformedNumber = getHexagramNumber(transformed);
+  const transformedDetails = ichingData[transformedNumber];
+  return { changingLines, changingLineDetails, transformed, transformedNumber, transformedDetails };
+}
+
 export default function Home() {
   const [question, setQuestion] = useState('');
   const [result, setResult] = useState(null);
@@ -49,7 +68,6 @@ export default function Home() {
     let changingLineDetails = [];
     if (hasChanging) {
       const processed = processChangingLines(hex, details);
-      changingLines.push(...processed.changingLines);
       changingLineDetails = processed.changingLineDetails;
       transformed = processed.transformed;
       transformedNumber = processed.transformedNumber;


### PR DESCRIPTION
## Summary
- add `processChangingLines` helper to generate transformed hexagram data
- use the helper inside `pages/index.js`
- clean up stray response lines in `pages/api/reading.js`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fe84310d0832eaf623c26192795ba