### PR TITLE
Add Tailwind and shadcn UI

### DIFF
--- a/components/ui/button.js
+++ b/components/ui/button.js
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export const Button = React.forwardRef(function Button({ className, variant, size, ...props }, ref) {
+  return (
+    <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+  );
+});

--- a/components/ui/card.js
+++ b/components/ui/card.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export const Card = React.forwardRef(function Card({ className, ...props }, ref) {
+  return <div ref={ref} className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...props} />;
+});
+
+export const CardHeader = React.forwardRef(function CardHeader({ className, ...props }, ref) {
+  return <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
+});
+
+export const CardTitle = React.forwardRef(function CardTitle({ className, ...props }, ref) {
+  return <h3 ref={ref} className={cn('text-2xl font-semibold tracking-tight', className)} {...props} />;
+});
+
+export const CardContent = React.forwardRef(function CardContent({ className, ...props }, ref) {
+  return <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />;
+});

--- a/components/ui/textarea.js
+++ b/components/ui/textarea.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export const Textarea = React.forwardRef(function Textarea({ className, ...props }, ref) {
+  return (
+    <textarea
+      className={cn('flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50', className)}
+      ref={ref}
+      {...props}
+    />
+  );
+});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,14 @@
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
+        "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/postcss": "^4.1.10",
+        "autoprefixer": "^10.4.21",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "postcss": "^8.5.5",
+        "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10"
       }
     },
@@ -651,6 +657,51 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -942,6 +993,77 @@
         "tailwindcss": "4.1.10"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
+      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001718",
+        "electron-to-chromium": "^1.5.160",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -983,11 +1105,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -1044,6 +1189,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.167",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
+      "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
@@ -1056,6 +1208,30 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/graceful-fs": {
@@ -1470,6 +1646,23 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1504,6 +1697,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -1637,6 +1837,17 @@
         }
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
@@ -1677,6 +1888,37 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,14 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/postcss": "^4.1.10",
+    "autoprefixer": "^10.4.21",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "postcss": "^8.5.5",
+    "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import Head from 'next/head';
 import ichingData from '../resources/iching/data/iching.js';
+import { Button } from '../components/ui/button';
+import { Textarea } from '../components/ui/textarea';
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 
 const CHANGING_YANG = 9;  // Three heads
 const YANG = 7;           // Two heads, one tail
@@ -88,87 +91,100 @@ export default function Home() {
   };
 
   return (
-    <div className="container">
+    <div className="mx-auto max-w-2xl p-4">
       <Head>
         <title>Oracular Consultant</title>
-        <link rel="stylesheet" href="/iching.css" />
       </Head>
       {!result && (
-        <ul className="responsive-table">
-          <li className="table-header">
-            <div className="comment-section">
-              <h1><strong>Present your question to the Oracle:</strong></h1>
-              <form onSubmit={handleSubmit}>
-                <textarea value={question} onChange={e => setQuestion(e.target.value)} placeholder="Write your question here." required /><br /><br />
-                <input type="submit" value="Ask" />
-              </form>
-            </div>
-          </li>
-        </ul>
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>Present your question to the Oracle</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <Textarea value={question} onChange={e => setQuestion(e.target.value)} placeholder="Write your question here." required />
+              <Button type="submit">Ask</Button>
+            </form>
+          </CardContent>
+        </Card>
       )}
       {result && (
-        <div>
-          <h2>Oracular Consultation</h2>
-          <ul className="responsive-table">
-            <li className="table-header">
-              <div className="comment-section">
-                <h1><strong>Focal query:</strong></h1><br /><br /><h2><em>{result.question}</em></h2>
-              </div>
-            </li>
-            <li className="table-header">
-              <div className="comment-section">
-                <h1><strong>Oracular Response:</strong></h1>
-                <h3>Primary Symbol: {result.number}</h3>
-                <h1><span style={{ fontSize: '3.5em' }}>{result.details.hex_font}</span></h1>
-                <strong><em>{result.details.english}</em></strong><br />
-                <p>{result.details.wilhelm_symbolic}</p>
-              </div>
-            </li>
-              {result.details.wilhelm_judgment && (
-                <li className="table-header">
-                  <div className="comment-section">
-                    <h3>Oracular Domain</h3>
-                    <p>{result.details.wilhelm_judgment.text}</p>
-                    <p><strong>Explanation:</strong> {result.details.wilhelm_judgment.comments}</p>
-                  </div>
-                </li>
-              )}
-              {result.details.wilhelm_image && (
-                <li className="table-header">
-                  <div className="comment-section">
-                    <h3>Oracular Image</h3>
-                    <p>{result.details.wilhelm_image.text}</p>
-                    <p><strong>Explanation:</strong> {result.details.wilhelm_image.comments}</p>
-                  </div>
-                </li>
-              )}
-            {result.changingLineDetails && result.changingLineDetails.length > 0 && (
-              <li className="table-header">
-                <div className="comment-section">
-                  <h3>Changing Layers</h3>
-                  {result.changingLineDetails.map(l => (
-                    <p key={l.line}>
-                      <strong>Layer {l.line}:</strong> {l.text}<br />
-                      <em>{l.comments}</em>
-                    </p>
-                  ))}
-                </div>
-              </li>
-            )}
-            {result.hasChanging && (
-              <li className="table-header">
-                <div className="comment-section">
-                  <h3>Looking Forward</h3>
-                  <p>There is only now, there is only here. The developing situation as shown by the layers of change, show the most probable result in response to your question.
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Focal query</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center italic">{result.question}</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Oracular Response</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-center">
+              <h3 className="text-lg font-semibold">Primary Symbol: {result.number}</h3>
+              <div className="text-5xl">{result.details.hex_font}</div>
+              <p className="font-semibold italic">{result.details.english}</p>
+              <p>{result.details.wilhelm_symbolic}</p>
+            </CardContent>
+          </Card>
+
+          {result.details.wilhelm_judgment && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Oracular Domain</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p>{result.details.wilhelm_judgment.text}</p>
+                <p className="text-sm"><strong>Explanation:</strong> {result.details.wilhelm_judgment.comments}</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {result.details.wilhelm_image && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Oracular Image</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p>{result.details.wilhelm_image.text}</p>
+                <p className="text-sm"><strong>Explanation:</strong> {result.details.wilhelm_image.comments}</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {result.changingLineDetails && result.changingLineDetails.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Changing Layers</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {result.changingLineDetails.map(l => (
+                  <p key={l.line}>
+                    <strong>Layer {l.line}:</strong> {l.text}<br />
+                    <em>{l.comments}</em>
                   </p>
-                  <h3>Symbol: {result.transformedNumber}</h3>
-                  <h1><span style={{ fontSize: '3.5em' }}>{result.transformedDetails.hex_font}</span></h1>
-                  <p><strong>Symbolic Name:</strong><br /> {result.transformedDetails.english}<br /></p>
-                  <p><strong>Symbolic Meaning:</strong><br /><br /> {result.transformedDetails.wilhelm_symbolic}</p>
-                </div>
-              </li>
-            )}
-          </ul>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {result.hasChanging && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Looking Forward</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-center">
+                <p>There is only now, there is only here. The developing situation as shown by the layers of change, show the most probable result in response to your question.</p>
+                <h3 className="text-lg font-semibold">Symbol: {result.transformedNumber}</h3>
+                <div className="text-5xl">{result.transformedDetails.hex_font}</div>
+                <p><strong>Symbolic Name:</strong> {result.transformedDetails.english}</p>
+                <p><strong>Symbolic Meaning:</strong> {result.transformedDetails.wilhelm_symbolic}</p>
+              </CardContent>
+            </Card>
+          )}
         </div>
       )}
     </div>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import url('/iching.css');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,jsx}',
+    './components/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add TailwindCSS configuration and global styles
- add helper `cn` and UI components from shadcn (button, card, textarea)
- wrap Next.js pages with `_app` for global styles
- refactor `index.js` to use new components and Tailwind classes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ffcf31054832ebe18953a6448647f