### PR TITLE
Add POST support for readings

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,9 +16,23 @@ The application will be available at `http://localhost:4545`.
 ### `GET /api/reading`
 Generate a random I‑Ching reading. The optional `question` query parameter is echoed back in the response.
 
-**Example**
+### `POST /api/reading`
+Send a JSON body containing a `question` field and receive the full reading response.
+Use this method when you prefer to provide the question in the request body instead of the query string.
+
+**Example (GET)**
 ```http
 GET http://localhost:4545/api/reading?question=What%20is%20my%20path
+```
+
+**Example (POST)**
+```http
+POST http://localhost:4545/api/reading
+Content-Type: application/json
+
+{
+  "question": "What is my path"
+}
 ```
 
 Response structure:

--- a/pages/api/reading.js
+++ b/pages/api/reading.js
@@ -1,6 +1,8 @@
 // API route to generate a random hexagram reading.
 // This allows Oraculo to be consumed as a module in larger projects.
-// Query parameter `question` is optional and echoed back in the response.
+// A question can be provided either as a query parameter (GET)
+// or in the JSON body of a POST request. The question value is
+// echoed back in the response.
 
 import ichingData from '../../resources/iching/data/iching.js';
 
@@ -39,11 +41,15 @@ function hexagramIdFromLines(hex) {
 }
 
 export default function handler(req, res) {
-  if (req.method !== 'GET') {
+  if (req.method !== 'GET' && req.method !== 'POST') {
     res.status(405).json({ error: 'Method Not Allowed' });
     return;
   }
-  const question = Array.isArray(req.query.question) ? req.query.question[0] : (req.query.question || '');
+  const question = req.method === 'POST'
+    ? (req.body && req.body.question) || ''
+    : Array.isArray(req.query.question)
+      ? req.query.question[0]
+      : (req.query.question || '');
   const hex = generateHexagram();
   const number = hexagramIdFromLines(hex);
   const details = ichingData[number];


### PR DESCRIPTION
## Summary
- allow POST requests on `/api/reading` so questions can be passed in the JSON body
- document new POST behaviour in API docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ffffec348832ead737d77c892b7db