### PR TITLE
Fix missing Link import in sidebar layout

### DIFF
--- a/components/layout/sidebar-layout.js
+++ b/components/layout/sidebar-layout.js
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Menu, X, BookOpen } from 'lucide-react';
+import Link from 'next/link';
 import { Button } from '../ui/button';
 
 export default function SidebarLayout({ children }) {


### PR DESCRIPTION
## Summary
- import Next.js Link component in sidebar layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685005b2fbbc832eb70c0963d7c5025c