### PR TITLE
Use shadcn typography in index page

### DIFF
--- a/components/ui/typography.tsx
+++ b/components/ui/typography.tsx
@@ -1,0 +1,129 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const H1 = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h1
+    ref={ref}
+    className={cn(
+      "scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl",
+      className
+    )}
+    {...props}
+  />
+))
+H1.displayName = "H1"
+
+const H2 = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h2
+    ref={ref}
+    className={cn(
+      "scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+H2.displayName = "H2"
+
+const H3 = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "scroll-m-20 text-2xl font-semibold tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+H3.displayName = "H3"
+
+const H4 = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h4
+    ref={ref}
+    className={cn(
+      "scroll-m-20 text-xl font-semibold tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+H4.displayName = "H4"
+
+const P = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn("leading-7 [&:not(:first-child)]:mt-6", className)}
+      {...props}
+    />
+  )
+)
+P.displayName = "P"
+
+const Blockquote = React.forwardRef<
+  HTMLQuoteElement,
+  React.HTMLAttributes<HTMLQuoteElement>
+>(({ className, ...props }, ref) => (
+  <blockquote
+    ref={ref}
+    className={cn("mt-6 border-l-2 pl-6 italic", className)}
+    {...props}
+  />
+))
+Blockquote.displayName = "Blockquote"
+
+const InlineCode = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+  ({ className, ...props }, ref) => (
+    <code
+      ref={ref}
+      className={cn(
+        "relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+InlineCode.displayName = "InlineCode"
+
+const Lead = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-xl text-muted-foreground", className)} {...props} />
+  )
+)
+Lead.displayName = "Lead"
+
+const Large = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+  )
+)
+Large.displayName = "Large"
+
+const Small = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+  ({ className, ...props }, ref) => (
+    <small ref={ref} className={cn("text-sm font-medium leading-none", className)} {...props} />
+  )
+)
+Small.displayName = "Small"
+
+const Muted = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+)
+Muted.displayName = "Muted"
+
+export { H1, H2, H3, H4, P, Blockquote, InlineCode, Lead, Large, Small, Muted }

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,7 @@ import ichingData from '../resources/iching/data/iching.js';
 import { Button } from '../components/ui/button';
 import { Textarea } from '../components/ui/textarea';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { H1, H3, P, Small } from '../components/ui/typography';
 
 const CHANGING_YANG = 9;  // Three heads
 const YANG = 7;           // Two heads, one tail
@@ -96,7 +97,7 @@ export default function Home() {
         <title>Oracular Consultant</title>
       </Head>
       {!result && (
-        <Card className="mb-6">
+        <Card className="mb-6 bg-muted/50">
           <CardHeader>
             <CardTitle>Present your question to the Oracle</CardTitle>
           </CardHeader>
@@ -109,58 +110,69 @@ export default function Home() {
         </Card>
       )}
       {result && (
-        <Card className="print:shadow-none print:border print:p-8">
+        <Card className="print:shadow-none print:border print:p-8 bg-muted/50">
           <CardHeader>
             <CardTitle>Consultation</CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
             <section>
-              <h3 className="text-xl font-semibold mb-2">Question</h3>
-              <p className="text-center italic">{result.question}</p>
+              <H3 className="mb-2">Question</H3>
+              <P className="text-center italic">{result.question}</P>
             </section>
 
             <section className="text-center">
-              <h3 className="text-xl font-semibold mb-2">Primary Symbol: {result.number}</h3>
-              <h1 className="text-5xl mb-2">{result.details.hex_font}</h1>
-              <p className="font-semibold italic">{result.details.english}</p>
-              <p>{result.details.wilhelm_symbolic}</p>
+              <H3 className="mb-2">Primary Symbol: {result.number}</H3>
+              <H1 className="text-5xl mb-2">{result.details.hex_font}</H1>
+              <P className="font-semibold italic">{result.details.english}</P>
+              <P>{result.details.wilhelm_symbolic}</P>
             </section>
 
             {result.details.wilhelm_judgment && (
               <section>
-                <h3 className="text-xl font-semibold mb-2">Oracular Domain</h3>
-                <p>{result.details.wilhelm_judgment.text}</p>
-                <p className="text-sm"><strong>Explanation:</strong> {result.details.wilhelm_judgment.comments}</p>
+                <H3 className="mb-2">Oracular Domain</H3>
+                <P>{result.details.wilhelm_judgment.text}</P>
+                <Small>
+                  <strong>Explanation:</strong> {result.details.wilhelm_judgment.comments}
+                </Small>
               </section>
             )}
 
             {result.details.wilhelm_image && (
               <section>
-                <h3 className="text-xl font-semibold mb-2">Oracular Image</h3>
-                <p>{result.details.wilhelm_image.text}</p>
-                <p className="text-sm"><strong>Explanation:</strong> {result.details.wilhelm_image.comments}</p>
+                <H3 className="mb-2">Oracular Image</H3>
+                <P>{result.details.wilhelm_image.text}</P>
+                <Small>
+                  <strong>Explanation:</strong> {result.details.wilhelm_image.comments}
+                </Small>
               </section>
             )}
 
             {result.changingLineDetails && result.changingLineDetails.length > 0 && (
               <section>
-                <h3 className="text-xl font-semibold mb-2">Changing Layers</h3>
+                <H3 className="mb-2">Changing Layers</H3>
                 {result.changingLineDetails.map(l => (
-                  <p key={l.line}>
-                    <strong>Layer {l.line}:</strong> {l.text}<br />
+                  <P key={l.line}>
+                    <strong>Layer {l.line}:</strong> {l.text}
+                    <br />
                     <em>{l.comments}</em>
-                  </p>
+                  </P>
                 ))}
               </section>
             )}
 
             {result.hasChanging && (
               <section className="text-center">
-                <h3 className="text-xl font-semibold mb-2">Looking Forward</h3>
-                <p>There is only now, there is only here. The developing situation as shown by the layers of change, show the most probable result in response to your question.</p>
-                <h1 className="text-5xl mb-2">{result.transformedDetails.hex_font}</h1>
-                <p><strong>Symbolic Name:</strong> {result.transformedDetails.english}</p>
-                <p><strong>Symbolic Meaning:</strong> {result.transformedDetails.wilhelm_symbolic}</p>
+                <H3 className="mb-2">Looking Forward</H3>
+                <P>
+                  There is only now, there is only here. The developing situation as shown by the layers of change, show the most probable result in response to your question.
+                </P>
+                <H1 className="text-5xl mb-2">{result.transformedDetails.hex_font}</H1>
+                <P>
+                  <strong>Symbolic Name:</strong> {result.transformedDetails.english}
+                </P>
+                <P>
+                  <strong>Symbolic Meaning:</strong> {result.transformedDetails.wilhelm_symbolic}
+                </P>
               </section>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary
- add shadcn typography components
- refresh home page to use shadcn typography components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685034dbf29c832eaf43bdb1bc158327