### PR TITLE
Add CORS headers for API

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,0 +1,8 @@
+export function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization'
+  );
+}

--- a/pages/api/hexagram/[id].js
+++ b/pages/api/hexagram/[id].js
@@ -2,8 +2,16 @@
 // Access via `/api/hexagram/23` to retrieve hexagram 23 details.
 
 import ichingData from '../../../resources/iching/data/iching.js';
+import { setCors } from '../../../lib/cors.js';
 
 export default function handler(req, res) {
+  setCors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
   const { id } = req.query;
   const numericId = parseInt(id, 10);
   if (isNaN(numericId)) {

--- a/pages/api/reading.js
+++ b/pages/api/reading.js
@@ -5,6 +5,7 @@
 // echoed back in the response.
 
 import ichingData from '../../resources/iching/data/iching.js';
+import { setCors } from '../../lib/cors.js';
 
 const CHANGING_YANG = 9;  // Three heads
 const YANG = 7;           // Two heads, one tail
@@ -41,6 +42,13 @@ function hexagramIdFromLines(hex) {
 }
 
 export default function handler(req, res) {
+  setCors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
   if (req.method !== 'GET' && req.method !== 'POST') {
     res.status(405).json({ error: 'Method Not Allowed' });
     return;


### PR DESCRIPTION
## Summary
- fix cross-origin issues by setting basic CORS headers
- handle `OPTIONS` requests in API routes

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685217ca0abc832e9a6f57595b7969f3